### PR TITLE
feat: add support for rewriting external imports in Deno plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,51 @@ be resolved).
    });
    ```
 1. Run `deno task bundle`.
+
+## Advanced Usage
+
+### External Dependencies with Deno Specifiers
+
+By default, dependencies marked as `external` in your Rolldown config will use
+their bare specifiers (e.g., `"chalk"`, `"@std/assert"`). If you want the
+bundled output to use Deno's native `npm:`, `jsr:`, and `https:` import
+specifiers instead, enable the `rewriteExternalSpecifiers` option:
+
+```js
+import denoPlugin from "@deno/rolldown-plugin";
+import { defineConfig } from "rolldown";
+
+export default defineConfig({
+  input: "./main.js",
+  output: {
+    file: "bundle.js",
+  },
+  external: ["chalk", "@std/assert"], // Mark as external
+  plugins: [
+    denoPlugin({
+      rewriteExternalSpecifiers: true, // Rewrite to Deno specifiers
+    }),
+  ],
+});
+```
+
+This will transform imports in the output bundle:
+
+```js
+// Before (bare specifiers):
+import chalk from "chalk";
+import { assertEquals } from "@std/assert";
+
+// After (Deno specifiers):
+import chalk from "npm:chalk@5.6.2";
+import { assertEquals } from "https://jsr.io/@std/assert/1.0.17/mod.ts";
+```
+
+**Benefits:**
+
+- The bundled code can run directly in Deno without additional configuration
+- Explicit version pinning from your deno.lock file
+- Works with npm, JSR, and HTTPS imports
+
+**Note:** Only dependencies marked in the `external` config will be rewritten.
+Bundled dependencies are not affected.

--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,7 @@
   "imports": {
     "@deno/loader": "jsr:@deno/loader@^0.3.0",
     "@std/assert": "jsr:@std/assert@^1.0.13",
-    "@std/path": "jsr:@std/path@^1.1.1"
+    "@std/path": "jsr:@std/path@^1.1.1",
+    "rolldown": "npm:rolldown@^1.0.0-rc.2"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -5,7 +5,8 @@
     "jsr:@std/assert@^1.0.13": "1.0.13",
     "jsr:@std/internal@^1.0.6": "1.0.8",
     "jsr:@std/internal@^1.0.9": "1.0.10",
-    "jsr:@std/path@^1.1.1": "1.1.1"
+    "jsr:@std/path@^1.1.1": "1.1.1",
+    "npm:rolldown@^1.0.0-rc.2": "1.0.0-rc.2"
   },
   "jsr": {
     "@deno/loader@0.3.0": {
@@ -30,11 +31,146 @@
       ]
     }
   },
+  "npm": {
+    "@emnapi/core@1.8.1": {
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "dependencies": [
+        "@emnapi/wasi-threads",
+        "tslib"
+      ]
+    },
+    "@emnapi/runtime@1.8.1": {
+      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@emnapi/wasi-threads@1.1.0": {
+      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "@napi-rs/wasm-runtime@1.1.1": {
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dependencies": [
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util"
+      ]
+    },
+    "@oxc-project/types@0.111.0": {
+      "integrity": "sha512-bh54LJMafgRGl2cPQ/QM+tI5rWaShm/wK9KywEj/w36MhiPKXYM67H2y3q+9pr4YO7ufwg2AKdBAZkhHBD8ClA=="
+    },
+    "@rolldown/binding-android-arm64@1.0.0-rc.2": {
+      "integrity": "sha512-AGV80viZ4Hil4C16GFH+PSwq10jclV9oyRFhD+5HdowPOCJ+G+99N5AClQvMkUMIahTY8cX0SQpKEEWcCg6fSA==",
+      "os": ["android"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-darwin-arm64@1.0.0-rc.2": {
+      "integrity": "sha512-PYR+PQu1mMmQiiKHN2JiOctvH32Xc/Mf+Su2RSmWtC9BbIqlqsVWjbulnShk0imjRim0IsbkMMCN5vYQwiuqaA==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-darwin-x64@1.0.0-rc.2": {
+      "integrity": "sha512-X2G36Z6oh5ynoYpE2JAyG+uQ4kO/3N7XydM/I98FNk8VVgDKjajFF+v7TXJ2FMq6xa7Xm0UIUKHW2MRQroqoUA==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-freebsd-x64@1.0.0-rc.2": {
+      "integrity": "sha512-XpiFTsl9qjiDfrmJF6CE3dgj1nmSbxUIT+p2HIbXV6WOj/32btO8FKkWSsOphUwVinEt3R8HVkVrcLtFNruMMQ==",
+      "os": ["freebsd"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.2": {
+      "integrity": "sha512-zjYZ99e47Wlygs4hW+sQ+kshlO8ake9OoY2ecnJ9cwpDGiiIB9rQ3LgP3kt8j6IeVyMSksu//VEhc8Mrd1lRIw==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@rolldown/binding-linux-arm64-gnu@1.0.0-rc.2": {
+      "integrity": "sha512-Piso04EZ9IHV1aZSsLQVMOPTiCq4Ps2UPL3pchjNXHGJGFiB9U42s22LubPaEBFS+i6tCawS5EarIwex1zC4BA==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-linux-arm64-musl@1.0.0-rc.2": {
+      "integrity": "sha512-OwJCeMZlmjKsN9pfJfTmqYpe3JC+L6RO87+hu9ajRLr1Lh6cM2FRQ8e48DLRyRDww8Ti695XQvqEANEMmsuzLw==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-linux-x64-gnu@1.0.0-rc.2": {
+      "integrity": "sha512-uQqBmA8dTWbKvfqbeSsXNUssRGfdgQCc0hkGfhQN7Pf85wG2h0Fd/z2d+ykyT4YbcsjQdgEGxBNsg3v4ekOuEA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-linux-x64-musl@1.0.0-rc.2": {
+      "integrity": "sha512-ItZabVsICCYWHbP+jcAgNzjPAYg5GIVQp/NpqT6iOgWctaMYtobClc5m0kNtxwqfNrLXoyt998xUey4AvcxnGQ==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/binding-openharmony-arm64@1.0.0-rc.2": {
+      "integrity": "sha512-U4UYANwafcMXSUC0VqdrqTAgCo2v8T7SiuTYwVFXgia0KOl8jiv3okwCFqeZNuw/G6EWDiqhT8kK1DLgyLsxow==",
+      "os": ["openharmony"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-wasm32-wasi@1.0.0-rc.2": {
+      "integrity": "sha512-ZIWCjQsMon4tqRoao0Vzowjwx0cmFT3kublh2nNlgeasIJMWlIGHtr0d4fPypm57Rqx4o1h4L8SweoK2q6sMGA==",
+      "dependencies": [
+        "@napi-rs/wasm-runtime"
+      ],
+      "cpu": ["wasm32"]
+    },
+    "@rolldown/binding-win32-arm64-msvc@1.0.0-rc.2": {
+      "integrity": "sha512-NIo7vwRUPEzZ4MuZGr5YbDdjJ84xdiG+YYf8ZBfTgvIsk9wM0sZamJPEXvaLkzVIHpOw5uqEHXS85Gqqb7aaqQ==",
+      "os": ["win32"],
+      "cpu": ["arm64"]
+    },
+    "@rolldown/binding-win32-x64-msvc@1.0.0-rc.2": {
+      "integrity": "sha512-bLKzyLFbvngeNPZocuLo3LILrKwCrkyMxmRXs6fZYDrvh7cyZRw9v56maDL9ipPas0OOmQK1kAKYwvTs30G21Q==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
+    "@rolldown/pluginutils@1.0.0-rc.2": {
+      "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw=="
+    },
+    "@tybys/wasm-util@0.10.1": {
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
+    "rolldown@1.0.0-rc.2": {
+      "integrity": "sha512-1g/8Us9J8sgJGn3hZfBecX1z4U3y5KO7V/aV2U1M/9UUzLNqHA8RfFQ/NPT7HLxOIldyIgrcjaYTRvA81KhJIg==",
+      "dependencies": [
+        "@oxc-project/types",
+        "@rolldown/pluginutils"
+      ],
+      "optionalDependencies": [
+        "@rolldown/binding-android-arm64",
+        "@rolldown/binding-darwin-arm64",
+        "@rolldown/binding-darwin-x64",
+        "@rolldown/binding-freebsd-x64",
+        "@rolldown/binding-linux-arm-gnueabihf",
+        "@rolldown/binding-linux-arm64-gnu",
+        "@rolldown/binding-linux-arm64-musl",
+        "@rolldown/binding-linux-x64-gnu",
+        "@rolldown/binding-linux-x64-musl",
+        "@rolldown/binding-openharmony-arm64",
+        "@rolldown/binding-wasm32-wasi",
+        "@rolldown/binding-win32-arm64-msvc",
+        "@rolldown/binding-win32-x64-msvc"
+      ],
+      "bin": true
+    },
+    "tslib@2.8.1": {
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    }
+  },
   "workspace": {
     "dependencies": [
       "jsr:@deno/loader@0.3",
       "jsr:@std/assert@^1.0.13",
-      "jsr:@std/path@^1.1.1"
+      "jsr:@std/path@^1.1.1",
+      "npm:rolldown@^1.0.0-rc.2"
     ]
   }
 }

--- a/src/mod.test.ts
+++ b/src/mod.test.ts
@@ -296,6 +296,44 @@ Deno.test("renderChunk", async (t) => {
 
     await Deno.remove(tempDir, { recursive: true });
   });
+
+  await t.step(
+    "should normalize npm: and jsr: specifiers (remove extra slash)",
+    async () => {
+      const { tempDir, denoJson, testFile } = await prepareFiles({
+        code: 'import chalk from "chalk";\nconsole.log("test");',
+        imports: {
+          "chalk": "npm:chalk@^5.3.0",
+        },
+      });
+
+      using plugin = denoPlugin({
+        rewriteExternalSpecifiers: true,
+        configPath: denoJson,
+      });
+
+      plugin.options({ external: "chalk" });
+      await plugin.buildStart({ input: testFile });
+
+      const inputCode = `import e from"chalk";console.log("test");`;
+      const result = plugin.renderChunk(inputCode, { format: "es" });
+
+      assertEquals(
+        result !== null,
+        true,
+        "Result should not be null when rewriting is enabled",
+      );
+      // Should use npm:package@version (not npm:/package@version)
+      assertStringIncludes(result!.code, "npm:chalk@");
+      assertEquals(
+        result!.code.includes("npm:/"),
+        false,
+        "Should not contain npm:/ (with slash after colon)",
+      );
+
+      await Deno.remove(tempDir, { recursive: true });
+    },
+  );
 });
 
 async function prepareFiles(

--- a/src/mod.test.ts
+++ b/src/mod.test.ts
@@ -1,6 +1,6 @@
 import denoPlugin from "./mod.ts";
-import { assertEquals } from "@std/assert";
-import { fromFileUrl } from "@std/path";
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
 
 Deno.test("should load and resolve", async () => {
   const plugin = denoPlugin({
@@ -29,3 +29,292 @@ Deno.test("should load and resolve", async () => {
     assertEquals(value.id, "node:events");
   }
 });
+
+Deno.test("renderChunk", async (t) => {
+  await t.step(
+    "should not rewrite when feature is disabled (default)",
+    async () => {
+      using plugin = denoPlugin();
+
+      const { tempDir, testFile } = await prepareFiles({
+        code: 'import chalk from "chalk";\nconsole.log("test");',
+        imports: {
+          "chalk": "npm:chalk@^5.3.0",
+        },
+      });
+
+      plugin.options({ external: "chalk" });
+      await plugin.buildStart({ input: testFile });
+
+      const inputCode = `import e from"chalk";console.log("test");`;
+      const result = plugin.renderChunk(inputCode, { format: "es" });
+
+      // Should return null when feature is disabled
+      assertEquals(result, null);
+
+      await Deno.remove(tempDir, { recursive: true });
+    },
+  );
+
+  await t.step("should rewrite with string external", async () => {
+    const { tempDir, denoJson, testFile } = await prepareFiles({
+      code: 'import chalk from "chalk";\nconsole.log("test");',
+      imports: {
+        "chalk": "npm:chalk@^5.3.0",
+      },
+    });
+
+    using plugin = denoPlugin({
+      rewriteExternalSpecifiers: true,
+      configPath: denoJson,
+    });
+
+    plugin.options({ external: "chalk" });
+    await plugin.buildStart({ input: testFile });
+
+    const inputCode = `import e from"chalk";console.log("test");`;
+    const result = plugin.renderChunk(inputCode, { format: "es" });
+
+    // Should rewrite chalk to npm: specifier
+    assertEquals(
+      result !== null,
+      true,
+      "Result should not be null when rewriting is enabled",
+    );
+    assertStringIncludes(result!.code, "npm:");
+    assertStringIncludes(result!.code, "chalk");
+    assertEquals(
+      result!.code.includes('from"chalk"'),
+      false,
+      "Should not contain bare 'chalk' import",
+    );
+
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  await t.step("should rewrite with array external", async () => {
+    const { tempDir, denoJson, testFile } = await prepareFiles({
+      code:
+        'import chalk from "chalk";\nimport { assertEquals } from "@std/assert";\nconsole.log("test");',
+      imports: {
+        "chalk": "npm:chalk@^5.3.0",
+        "@std/assert": "jsr:@std/assert@^1.0.0",
+      },
+    });
+
+    using plugin = denoPlugin({
+      rewriteExternalSpecifiers: true,
+      configPath: denoJson,
+    });
+
+    plugin.options({ external: ["chalk", "@std/assert"] });
+    await plugin.buildStart({ input: testFile });
+
+    const inputCode =
+      `import e from"chalk";import{assertEquals as t}from"@std/assert";console.log("test");`;
+    const result = plugin.renderChunk(inputCode, { format: "es" });
+
+    assertEquals(
+      result !== null,
+      true,
+      "Result should not be null when rewriting is enabled",
+    );
+    // Should contain npm: for chalk
+    assertStringIncludes(result!.code, "npm:");
+    // Should contain jsr: or https://jsr.io for @std/assert
+    const hasJsr = result!.code.includes("jsr:") ||
+      result!.code.includes("https://jsr.io");
+    assertEquals(hasJsr, true, "Should contain JSR specifier");
+
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  await t.step("should rewrite with regex external", async () => {
+    const { tempDir, denoJson, testFile } = await prepareFiles({
+      code:
+        'import chalk from "chalk";\nimport { assertEquals } from "@std/assert";\nconsole.log("test");',
+      imports: {
+        "chalk": "npm:chalk@^5.3.0",
+        "@std/assert": "jsr:@std/assert@^1.0.0",
+      },
+    });
+
+    using plugin = denoPlugin({
+      rewriteExternalSpecifiers: true,
+      configPath: denoJson,
+    });
+
+    plugin.options({ external: /^(chalk|@std\/)/ });
+    await plugin.buildStart({ input: testFile });
+
+    const inputCode =
+      `import e from"chalk";import{assertEquals as t}from"@std/assert";console.log("test");`;
+    const result = plugin.renderChunk(inputCode, { format: "es" });
+
+    assertEquals(
+      result !== null,
+      true,
+      "Result should not be null when rewriting is enabled",
+    );
+    const hasNpmOrJsr = result!.code.includes("npm:") ||
+      result!.code.includes("jsr:") ||
+      result!.code.includes("https://jsr.io");
+    assertEquals(hasNpmOrJsr, true, "Should contain npm: or jsr: specifiers");
+
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  await t.step("should only rewrite matching externals", async () => {
+    const { tempDir, denoJson, testFile } = await prepareFiles({
+      code:
+        'import chalk from "chalk";\nimport { assertEquals } from "@std/assert";\nconsole.log("test");',
+      imports: {
+        "chalk": "npm:chalk@^5.3.0",
+        "@std/assert": "jsr:@std/assert@^1.0.0",
+      },
+    });
+
+    using plugin = denoPlugin({
+      rewriteExternalSpecifiers: true,
+      configPath: denoJson,
+    });
+
+    // Only mark chalk as external, not @std/assert
+    plugin.options({ external: "chalk" });
+    await plugin.buildStart({ input: testFile });
+
+    const inputCode =
+      `import e from"chalk";import{assertEquals as t}from"@std/assert";console.log("test");`;
+    const result = plugin.renderChunk(inputCode, { format: "es" });
+
+    assertEquals(
+      result !== null,
+      true,
+      "Result should not be null when rewriting is enabled",
+    );
+    // Should rewrite chalk
+    assertStringIncludes(result!.code, "npm:");
+    assertStringIncludes(result!.code, "chalk");
+
+    // @std/assert should NOT be rewritten since it's not in external config
+    // Rolldown will in fact bundle it, but at this stage we just check that the import remains unchanged
+    assertEquals(
+      result!.code.includes('from"@std/assert"'),
+      true,
+      "Should still contain bare '@std/assert' import",
+    );
+    assertEquals(
+      result!.code.includes("jsr:@std/assert"),
+      false,
+      "Should NOT contain rewritten JSR specifier",
+    );
+
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  await t.step("should handle dynamic imports", async () => {
+    const { tempDir, denoJson, testFile } = await prepareFiles({
+      code: 'import("chalk").then(m=>console.log(m));',
+      imports: {
+        "chalk": "npm:chalk@^5.3.0",
+      },
+    });
+
+    using plugin = denoPlugin({
+      rewriteExternalSpecifiers: true,
+      configPath: denoJson,
+    });
+
+    plugin.options({ external: "chalk" });
+    await plugin.buildStart({ input: testFile });
+
+    const inputCode = `import("chalk").then(m=>console.log(m));`;
+    const result = plugin.renderChunk(inputCode, { format: "es" });
+
+    assertEquals(
+      result !== null,
+      true,
+      "Result should not be null when rewriting is enabled",
+    );
+    // Dynamic import should also be rewritten
+    assertStringIncludes(result!.code, 'import("npm:');
+    assertStringIncludes(result!.code, "chalk");
+
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  await t.step("should preserve code when no externals match", async () => {
+    using plugin = denoPlugin({
+      rewriteExternalSpecifiers: true,
+    });
+
+    const { tempDir, testFile } = await prepareFiles({
+      code: 'console.log("test");',
+      imports: {},
+    });
+
+    plugin.options({ external: "nonexistent-package" });
+    await plugin.buildStart({ input: testFile });
+
+    const inputCode = `console.log("test");`;
+    const result = plugin.renderChunk(inputCode, { format: "es" });
+
+    // Should return null when no rewrites are needed
+    assertEquals(result, null);
+
+    await Deno.remove(tempDir, { recursive: true });
+  });
+
+  await t.step("should handle export statements", async () => {
+    const { tempDir, denoJson, testFile } = await prepareFiles({
+      code: 'export { assertEquals } from "@std/assert";',
+      imports: {
+        "@std/assert": "jsr:@std/assert@^1.0.0",
+      },
+    });
+
+    using plugin = denoPlugin({
+      rewriteExternalSpecifiers: true,
+      configPath: denoJson,
+    });
+
+    plugin.options({ external: "@std/assert" });
+    await plugin.buildStart({ input: testFile });
+
+    const inputCode = `export{assertEquals as e}from"@std/assert";`;
+    const result = plugin.renderChunk(inputCode, { format: "es" });
+
+    assertEquals(
+      result !== null,
+      true,
+      "Result should not be null when rewriting is enabled",
+    );
+    // Export statement should also be rewritten
+    const hasJsr = result!.code.includes("jsr:") ||
+      result!.code.includes("https://jsr.io");
+    assertEquals(hasJsr, true, "Should rewrite export from statement");
+
+    await Deno.remove(tempDir, { recursive: true });
+  });
+});
+
+async function prepareFiles(
+  input: { code: string; imports: Record<string, string> },
+) {
+  const tempDir = await Deno.makeTempDir();
+  const denoJson = join(tempDir, "deno.json");
+  const testFile = join(tempDir, "test.ts");
+
+  await Promise.all([
+    Deno.writeTextFile(
+      denoJson,
+      JSON.stringify({ imports: input.imports }),
+    ),
+    Deno.writeTextFile(
+      testFile,
+      input.code,
+    ),
+  ]);
+
+  return { tempDir, denoJson, testFile };
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -232,16 +232,21 @@ function buildExternalMappings(
       // Skip if resolvedSpecifier is not a string (importing an unknown package)
       if (!resolvedSpecifier || typeof resolvedSpecifier !== "string") continue;
 
+      // Deno's loader returns specifiers as canonical URLs
+      const normalizedSpecifier = resolvedSpecifier
+        .replace(/^npm:\//, "npm:")
+        .replace(/^jsr:\//, "jsr:");
+
       // Only add if it's an npm/jsr/https import AND matches rolldownExternal
-      const isExternalProtocol = resolvedSpecifier.startsWith("npm:") ||
-        resolvedSpecifier.startsWith("jsr:") ||
-        resolvedSpecifier.startsWith("https:");
+      const isExternalProtocol = normalizedSpecifier.startsWith("npm:") ||
+        normalizedSpecifier.startsWith("jsr:") ||
+        normalizedSpecifier.startsWith("https:");
 
       if (
         isExternalProtocol &&
         isMatchingExternal(bareSpecifier, rolldownExternal)
       ) {
-        mappings.set(bareSpecifier, resolvedSpecifier);
+        mappings.set(bareSpecifier, normalizedSpecifier);
       }
     }
   }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -8,6 +8,30 @@ import {
   type WorkspaceOptions,
 } from "@deno/loader";
 import { fromFileUrl } from "@std/path/from-file-url";
+import type { ExternalOption, RolldownOptions } from "rolldown";
+
+interface LoaderGraph {
+  roots: string[];
+  modules: {
+    kind: string;
+    dependencies: {
+      specifier: string;
+      code: {
+        specifier: string;
+        resolutionMode: string;
+        span: {
+          start: { line: number; character: number };
+          end: { line: number; character: number };
+        };
+      };
+    }[];
+    size: number;
+    mediaType: string;
+    specifier: string;
+  }[];
+  redirects: Record<string, string>;
+  packages: Record<string, string>;
+}
 
 interface Module {
   specifier: string;
@@ -16,6 +40,13 @@ interface Module {
 
 /** Options for creating the Deno plugin. */
 export interface DenoPluginOptions extends WorkspaceOptions {
+  /**
+   * When true, rewrites external imports to use Deno-resolved specifiers
+   * (e.g., "chalk" -> "npm:/chalk@5.6.2").
+   * Only applies to dependencies marked as external in Rolldown config.
+   * @default false
+   */
+  rewriteExternalSpecifiers?: boolean;
 }
 
 export interface BuildStartOptions {
@@ -26,8 +57,13 @@ export interface ResolveIdOptions {
   kind: "import-statement" | "dynamic-import" | "require-call";
 }
 
+export interface RenderChunkOptions {
+  format: string;
+}
+
 export interface DenoPlugin extends Disposable {
   name: string;
+  options(options: RolldownOptions): void;
   buildStart(options: BuildStartOptions): Promise<void>;
   resolveId(
     source: string,
@@ -35,6 +71,7 @@ export interface DenoPlugin extends Disposable {
     options: ResolveIdOptions,
   ): Promise<string | { id: string; external: boolean }>;
   load(id: string): string | undefined;
+  renderChunk(code: string, chunk: RenderChunkOptions): { code: string } | null;
 }
 
 /**
@@ -47,11 +84,16 @@ export default function denoPlugin(
   let loader: Loader;
   const loads = new Map<string, Promise<LoadResponse | undefined>>();
   const modules = new Map<string, Module | undefined>();
+  let rolldownExternal: ExternalOption | undefined = undefined;
+  let graph: LoaderGraph | undefined = undefined;
 
   return {
     name: "deno-plugin",
     [Symbol.dispose]() {
       loader?.[Symbol.dispose]();
+    },
+    options(options: RolldownOptions) {
+      rolldownExternal = options.external;
     },
     async buildStart(options: BuildStartOptions) {
       const inputs = Array.isArray(options.input)
@@ -65,6 +107,7 @@ export default function denoPlugin(
       });
       loader = await workspace.createLoader();
       await loader.addEntrypoints(inputs);
+      graph = loader.getGraphUnstable() as LoaderGraph;
     },
     async resolveId(
       source: string,
@@ -121,7 +164,130 @@ export default function denoPlugin(
     load(id: string) {
       return modules.get(id)?.code;
     },
+    renderChunk(code: string) {
+      if (!pluginOptions.rewriteExternalSpecifiers || !graph) return null;
+
+      // Rewrite external imports to use Deno specifiers
+      let modifiedCode = code;
+      const externalMappings = buildExternalMappings(graph, rolldownExternal);
+
+      if (pluginOptions.debug && externalMappings.size > 0) {
+        console.error(
+          "External mappings:",
+          Array.from(externalMappings.entries()),
+        );
+      }
+
+      // Replace import/export statements with Deno specifiers
+      for (const [bareSpecifier, denoSpecifier] of externalMappings) {
+        // Match: import ... from "bareSpecifier" or import ... from 'bareSpecifier'
+        // Also match: export ... from "bareSpecifier"
+        const importRegex = new RegExp(
+          `((?:import|export)(?:[^"']*?)from\\s*["'])${
+            escapeRegExp(bareSpecifier)
+          }(["'])`,
+          "g",
+        );
+        const dynamicImportRegex = new RegExp(
+          `(import\\s*\\(\\s*["'])${escapeRegExp(bareSpecifier)}(["']\\s*\\))`,
+          "g",
+        );
+
+        modifiedCode = modifiedCode.replace(
+          importRegex,
+          `$1${denoSpecifier}$2`,
+        );
+        modifiedCode = modifiedCode.replace(
+          dynamicImportRegex,
+          `$1${denoSpecifier}$2`,
+        );
+      }
+
+      return modifiedCode === code ? null : { code: modifiedCode };
+    },
   };
+}
+
+/**
+ * Builds a map of bare specifiers to their Deno-resolved specifiers.
+ * This is used in renderChunk to rewrite external imports.
+ * Only includes specifiers that match the rolldownExternal configuration.
+ */
+function buildExternalMappings(
+  graph: LoaderGraph,
+  rolldownExternal: ExternalOption | undefined,
+): Map<string, string> {
+  const mappings = new Map<string, string>();
+
+  for (const module of graph.modules) {
+    if (module.kind !== "esm" || !module.dependencies) continue;
+
+    for (const dep of module.dependencies) {
+      if (!dep.code) continue;
+
+      const bareSpecifier = dep.specifier;
+      const denoSpecifier = dep.code.specifier;
+      const resolvedSpecifier = graph.redirects[denoSpecifier] ?? denoSpecifier;
+
+      // Skip if resolvedSpecifier is not a string (importing an unknown package)
+      if (!resolvedSpecifier || typeof resolvedSpecifier !== "string") continue;
+
+      // Only add if it's an npm/jsr/https import AND matches rolldownExternal
+      const isExternalProtocol = resolvedSpecifier.startsWith("npm:") ||
+        resolvedSpecifier.startsWith("jsr:") ||
+        resolvedSpecifier.startsWith("https:");
+
+      if (
+        isExternalProtocol &&
+        isMatchingExternal(bareSpecifier, rolldownExternal)
+      ) {
+        mappings.set(bareSpecifier, resolvedSpecifier);
+      }
+    }
+  }
+
+  return mappings;
+}
+
+/**
+ * Checks if a specifier matches the rolldown external configuration.
+ */
+function isMatchingExternal(
+  specifier: string,
+  external: ExternalOption | undefined,
+): boolean {
+  if (!external) return false;
+
+  // Handle string
+  if (typeof external === "string") {
+    return specifier === external;
+  }
+
+  // Handle RegExp
+  if (external instanceof RegExp) {
+    return external.test(specifier);
+  }
+
+  // Handle function
+  if (typeof external === "function") {
+    // Call the function with minimal required args
+    // Note: We don't have full context here, so we pass what we can
+    return external(specifier, undefined, false) === true;
+  }
+
+  // Handle array
+  if (Array.isArray(external)) {
+    return external.some((ext) => isMatchingExternal(specifier, ext));
+  }
+
+  return false;
+}
+
+/**
+ * Escapes special regex characters in a string.
+ */
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 function mediaTypeToExtension(mediaType: MediaType) {


### PR DESCRIPTION
Feature Proposal: **External Dependency Rewriting for Deno**

### Problem

In some runtimes, like [BunnyCDN Edge Scripting](https://bunny.net/edge-scripting/), import maps are not available and default module resolution relies on native specifiers like `npm:`, `jsr:`, and `https:`.

When using Rolldown with the Deno plugin, external dependencies are preserved
using their bare specifiers. For example:

```js
// Bundled output
import chalk from "chalk"; // ❌ Won't work in Deno without import maps
```

### Solution

This PR adds an **opt-in** `rewriteExternalSpecifiers` option that automatically rewrites external dependencies to use Deno's native specifiers:

```js
// With rewriteExternalSpecifiers: true
import chalk from "npm:chalk@5.6.2";
```

### Why This Matters (IMO)

1. **Zero-config deployment**: Bundled code runs in Deno without import maps or additional configuration
2. **Version pinning**: Uses resolved versions from `deno.lock`, ensuring consistency
3. **Protocol-agnostic**: Works seamlessly with npm, JSR, and HTTPS imports
4. **Opt-in design**: Doesn't affect existing workflows; only activates when explicitly enabled

### Implementation

- Leverages the existing Deno loader's dependency graph (already available via `getGraphUnstable()`)
- Respects Rolldown's `external` configuration
- Added related test coverage
